### PR TITLE
Allowing Laravel 11 and PHP 8.3 installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2",
-        "laravel/framework": "^8.0|^9.0|^10.0",
+        "php": "^7.3|^8.0|^8.1|^8.2|^8.3",
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0",
         "laravel/nova": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
After some reviewing and testing locally, I suppose that nothing changes in this package for Laravel 11 and PHP 8.3, so it can be safely updated!

With this PR accepted, a new tag would need to be generated, and then installation will most likely work just fine in Laravel 11/PHP 8.3 :)

Cheers!