### PR TITLE
Upgrading PHP support to 8.4 and Laravel support to 12.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2|^8.3",
-        "laravel/framework": "^8.0|^9.0|^10.0|^11.0",
+        "php": "^7.3|^8.0|^8.1|^8.2|^8.3|^8.4",
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "laravel/nova": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
After reviewing the upgrade guide for both PHP 8.4 and Laravel 12.x, it seems that it should be safe to allow this package to be installed in both these new versions without any breaking changes.

**Its important to add that, in the near future, I will probably also open a PR to upgrade this package to Nova 5, which will probably require bigger changes due to the upgrades the Nova team made on the `inertiajs` version and the removal of `form-backend-validation`**. This is not something you should worry about just now. I will take care of it. I'm just letting you know that you might need to check this repository again in a few days/weeks.

Thanks once again for the awesome package. Cheers!